### PR TITLE
Update upstream

### DIFF
--- a/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
+++ b/activerecord/test/cases/adapters/sqlite3/sqlite3_adapter_test.rb
@@ -361,21 +361,48 @@ module ActiveRecord
       end
 
       class Barcode < ActiveRecord::Base
+        self.primary_key = "code"
       end
 
-      def test_existing_records_have_custom_primary_key
+      def test_copy_table_with_existing_records_have_custom_primary_key
         connection = Barcode.connection
         connection.create_table(:barcodes, primary_key: "code", id: :string, limit: 42, force: true) do |t|
           t.text :other_attr
         end
         code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
-        Barcode.create! code: code, other_attr: "xxx"
+        Barcode.create!(code: code, other_attr: "xxx")
 
         connection.change_table "barcodes" do |t|
           connection.remove_column("barcodes", "other_attr")
         end
 
         assert_equal code, Barcode.first.id
+      ensure
+        Barcode.reset_column_information
+      end
+
+      def test_copy_table_with_composite_primary_keys
+        connection = Barcode.connection
+        connection.create_table(:barcodes, primary_key: ["region", "code"], force: true) do |t|
+          t.string :region
+          t.string :code
+          t.text :other_attr
+        end
+        region = "US"
+        code = "214fe0c2-dd47-46df-b53b-66090b3c1d40"
+        Barcode.create!(region: region, code: code, other_attr: "xxx")
+
+        connection.change_table "barcodes" do |t|
+          connection.remove_column("barcodes", "other_attr")
+        end
+
+        assert_equal ["region", "code"], connection.primary_keys("barcodes")
+
+        barcode = Barcode.first
+        assert_equal region, barcode.region
+        assert_equal code, barcode.code
+      ensure
+        Barcode.reset_column_information
       end
 
       def test_supports_extensions


### PR DESCRIPTION
`connection.primary_key` also return composite primary keys, so
`from_primary_key_column` may not be found even if `from_primary_key` is
presented.

```
% ARCONN=sqlite3 be ruby -w -Itest
test/cases/adapters/sqlite3/sqlite3_adapter_test.rb -n
test_copy_table_with_composite_primary_keys
Using sqlite3
Run options: -n test_copy_table_with_composite_primary_keys --seed 19041

# Running:

E

Error:
ActiveRecord::ConnectionAdapters::SQLite3AdapterTest#test_copy_table_with_composite_primary_keys:
NoMethodError: undefined method `type' for nil:NilClass
    /path/to/rails/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb:411:in
    `block in copy_table'
```

This change fixes `copy_table` to do not lose composite primary keys.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
