### PR TITLE
Added info & package.json script useful for devs

### DIFF
--- a/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_and_belongs_to_many_associations_test.rb
@@ -310,6 +310,10 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build
     devel = Developer.find(1)
+
+    # Load schema information so we don't query below if running just this test.
+    Project.define_attribute_methods
+
     proj = assert_no_queries { devel.projects.build("name" => "Projekt") }
     assert_not_predicate devel.projects, :loaded?
 
@@ -325,6 +329,10 @@ class HasAndBelongsToManyAssociationsTest < ActiveRecord::TestCase
 
   def test_new_aliased_to_build
     devel = Developer.find(1)
+
+    # Load schema information so we don't query below if running just this test.
+    Project.define_attribute_methods
+
     proj = assert_no_queries { devel.projects.new("name" => "Projekt") }
     assert_not_predicate devel.projects, :loaded?
 

--- a/activerecord/test/cases/associations/has_many_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_associations_test.rb
@@ -458,6 +458,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_finder_method_with_dirty_target
     company = companies(:first_firm)
     new_clients = []
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     assert_no_queries do
       new_clients << company.clients_of_firm.build(name: "Another Client")
       new_clients << company.clients_of_firm.build(name: "Another Client II")
@@ -478,6 +482,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   def test_finder_bang_method_with_dirty_target
     company = companies(:first_firm)
     new_clients = []
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     assert_no_queries do
       new_clients << company.clients_of_firm.build(name: "Another Client")
       new_clients << company.clients_of_firm.build(name: "Another Client II")
@@ -955,8 +963,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_transactions_when_adding_to_new_record
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
+    firm = Firm.new
     assert_no_queries do
-      firm = Firm.new
       firm.clients_of_firm.concat(Client.new("name" => "Natural Company"))
     end
   end
@@ -970,6 +981,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_new_aliased_to_build
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_client = assert_no_queries { company.clients_of_firm.new("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
@@ -980,6 +995,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_client = assert_no_queries { company.clients_of_firm.build("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
@@ -1037,6 +1056,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build_many
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_clients = assert_no_queries { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
     assert_equal 2, new_clients.size
   end
@@ -1049,9 +1072,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build_without_loading_association
     first_topic = topics(:first)
-    Reply.column_names
 
     assert_equal 1, first_topic.replies.length
+
+    # Load schema information so we don't query below if running just this test.
+    Reply.define_attribute_methods
 
     assert_no_queries do
       first_topic.replies.build(title: "Not saved", content: "Superstars")
@@ -1063,6 +1088,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build_via_block
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_client = assert_no_queries { company.clients_of_firm.build { |client| client.name = "Another Client" } }
     assert_not_predicate company.clients_of_firm, :loaded?
 
@@ -1073,6 +1102,10 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_build_many_via_block
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_clients = assert_no_queries do
       company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) do |client|
         client.name = "changed"
@@ -1086,8 +1119,6 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
 
   def test_create_without_loading_association
     first_firm = companies(:first_firm)
-    Firm.column_names
-    Client.column_names
 
     assert_equal 2, first_firm.clients_of_firm.size
     first_firm.clients_of_firm.reset
@@ -1364,8 +1395,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_transaction_when_deleting_new_record
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
+    firm = Firm.new
     assert_no_queries do
-      firm = Firm.new
       client = Client.new("name" => "New Client")
       firm.clients_of_firm << client
       firm.clients_of_firm.destroy(client)
@@ -1822,8 +1856,11 @@ class HasManyAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_transactions_when_replacing_on_new_record
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
+    firm = Firm.new
     assert_no_queries do
-      firm = Firm.new
       firm.clients_of_firm = [Client.new("name" => "New Client")]
     end
   end

--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -274,6 +274,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
     assert_queries(1) { posts(:thinking) }
     new_person = nil # so block binding catches it
 
+    # Load schema information so we don't query below if running just this test.
+    Person.define_attribute_methods
+
     assert_no_queries do
       new_person = Person.new first_name: "bob"
     end
@@ -293,6 +296,9 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_associate_new_by_building
     assert_queries(1) { posts(:thinking) }
+
+    # Load schema information so we don't query below if running just this test.
+    Person.define_attribute_methods
 
     assert_no_queries do
       posts(:thinking).people.build(first_name: "Bob")

--- a/activerecord/test/cases/associations/has_one_associations_test.rb
+++ b/activerecord/test/cases/associations/has_one_associations_test.rb
@@ -231,9 +231,13 @@ class HasOneAssociationsTest < ActiveRecord::TestCase
   end
 
   def test_build_association_dont_create_transaction
-    assert_no_queries {
-      Firm.new.build_account
-    }
+    # Load schema information so we don't query below if running just this test.
+    Account.define_attribute_methods
+
+    firm = Firm.new
+    assert_no_queries do
+      firm.build_account
+    end
   end
 
   def test_building_the_associated_object_with_implicit_sti_base_class

--- a/activerecord/test/cases/autosave_association_test.rb
+++ b/activerecord/test/cases/autosave_association_test.rb
@@ -642,6 +642,10 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
   def test_build_before_save
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_client = assert_no_queries { company.clients_of_firm.build("name" => "Another Client") }
     assert_not_predicate company.clients_of_firm, :loaded?
 
@@ -653,6 +657,10 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
   def test_build_many_before_save
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     assert_no_queries { company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) }
 
     company.name += "-changed"
@@ -662,6 +670,10 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
   def test_build_via_block_before_save
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     new_client = assert_no_queries { company.clients_of_firm.build { |client| client.name = "Another Client" } }
     assert_not_predicate company.clients_of_firm, :loaded?
 
@@ -673,6 +685,10 @@ class TestDefaultAutosaveAssociationOnAHasManyAssociation < ActiveRecord::TestCa
 
   def test_build_many_via_block_before_save
     company = companies(:first_firm)
+
+    # Load schema information so we don't query below if running just this test.
+    Client.define_attribute_methods
+
     assert_no_queries do
       company.clients_of_firm.build([{ "name" => "Another Client" }, { "name" => "Another Client II" }]) do |client|
         client.name = "changed"


### PR DESCRIPTION
… CI flakiness

Follow up 45be690f8e6db019aac6198ba49d608a2e14824b.

Somehow calling `define_attribute_methods` in `build`/`new` sometimes
causes the `table_exists?` query.

To address CI flakiness due to `assert_no_queries` failure, ensure
`define_attribute_methods` before `assert_no_queries`.

### Summary

Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
